### PR TITLE
Feature/advisor chat

### DIFF
--- a/src/app/api/advice/chat/route.ts
+++ b/src/app/api/advice/chat/route.ts
@@ -5,6 +5,7 @@ import { ComlinkError } from "@/lib/swgoh/comlink/client";
 import { continueChat } from "@/lib/swgoh/advisor/client";
 import type { ChatMessage } from "@/lib/swgoh/advisor/client";
 import { createModel, DEFAULT_PROVIDER } from "@/lib/swgoh/advisor/providers";
+import { buildSystemPrompt } from "@/lib/swgoh/advisor/prompt";
 import type { ModeSelection, RotePurpose } from "@/lib/swgoh/advisor/prompt";
 
 interface ChatRequestBody {
@@ -68,20 +69,21 @@ export async function POST(request: NextRequest) {
 
     // AI に送信
     const model = createModel(DEFAULT_PROVIDER);
+    const system = buildSystemPrompt({
+      playerName: player.name,
+      allyCode: player.allyCode,
+      level: player.level,
+      guildName: player.guildName,
+      galacticPower: player.galacticPower,
+      characterGalacticPower: player.characterGalacticPower,
+      shipGalacticPower: player.shipGalacticPower,
+      topUnits,
+      allUnitsMap: player.units,
+      selection,
+    });
     const reply = await continueChat(
       {
-        systemPromptInput: {
-          playerName: player.name,
-          allyCode: player.allyCode,
-          level: player.level,
-          guildName: player.guildName,
-          galacticPower: player.galacticPower,
-          characterGalacticPower: player.characterGalacticPower,
-          shipGalacticPower: player.shipGalacticPower,
-          topUnits,
-          allUnitsMap: player.units,
-          selection,
-        },
+        system,
         history: fullHistory,
       },
       { model },

--- a/src/lib/swgoh/advisor/client.ts
+++ b/src/lib/swgoh/advisor/client.ts
@@ -11,8 +11,6 @@
 
 import type { LanguageModel } from "ai";
 import { generateText } from "ai";
-import { buildSystemPrompt } from "./prompt";
-import type { ChatSystemPromptInput } from "./prompt";
 
 // -------------------------------------------------------
 // 定数
@@ -48,11 +46,11 @@ export interface AdvisorConfig {
 
 /**
  * チャットセッションの入力
- * システムプロンプト + 会話履歴全体を受け取る
+ * システムプロンプト文字列 + 会話履歴全体を受け取る
  */
 export interface ChatInput {
-  /** システムプロンプト生成に必要なデータ */
-  systemPromptInput: ChatSystemPromptInput;
+  /** 事前に組み立て済みのシステムプロンプト文字列 */
+  system: string;
   /** これまでの会話履歴（user/assistant のやり取り） */
   history: ChatMessage[];
 }
@@ -115,10 +113,10 @@ async function callAI(
  * チャットセッションでAIにメッセージを送り、返答を得る
  *
  * 会話履歴（history）をそのまま渡す軽量版。
- * システムプロンプトはセッション開始時に1回組み立てられ、
- * 以降の呼び出しでも同じものを使い回す。
+ * システムプロンプトは呼び出し元で事前に組み立てて渡す。
+ * 呼び出し元でキャッシュすることで、同一セッション内での再生成を避けられる。
  *
- * @param input  - システムプロンプト入力データ + 会話履歴
+ * @param input  - 事前組み立て済みシステムプロンプト + 会話履歴
  * @param config - LanguageModel インスタンスと生成オプション
  * @returns 生成されたアドバイス文字列
  * @throws {AdvisorError} API 呼び出し失敗時
@@ -128,6 +126,5 @@ export async function continueChat(
   config: AdvisorConfig,
 ): Promise<string> {
   const { model, maxOutputTokens = DEFAULT_MAX_OUTPUT_TOKENS } = config;
-  const system = buildSystemPrompt(input.systemPromptInput);
-  return callAI(model, system, input.history, maxOutputTokens);
+  return callAI(model, input.system, input.history, maxOutputTokens);
 }


### PR DESCRIPTION
This pull request refactors how the system prompt is handled in the chat advisor API. Instead of generating the system prompt within the `continueChat` function, the prompt is now built earlier in the API route and passed as a pre-assembled string. This change simplifies the interface for chat sessions and allows for more efficient reuse of the system prompt within a session.

**Refactoring system prompt handling:**

* The `ChatInput` interface in `client.ts` now expects a pre-built `system` prompt string instead of the data needed to build it, clarifying its purpose and usage.
* The `continueChat` function no longer generates the system prompt internally; it receives the prompt string from its caller, improving efficiency and separation of concerns.
* The API route in `route.ts` now imports and calls `buildSystemPrompt` directly to assemble the prompt before calling `continueChat`. [[1]](diffhunk://#diff-dc703e4ab6306cc3650e3576c7289eb6ce335a1382c2040b4e581539379f745bR8) [[2]](diffhunk://#diff-dc703e4ab6306cc3650e3576c7289eb6ce335a1382c2040b4e581539379f745bL82-R83) [[3]](diffhunk://#diff-dc703e4ab6306cc3650e3576c7289eb6ce335a1382c2040b4e581539379f745bL95-R97)

**Documentation and code clarity:**

* Updated comments and parameter descriptions in `client.ts` to reflect that the system prompt is now built by the caller and can be cached for reuse, reducing redundant prompt generation.

**Code cleanup:**

* Removed unnecessary imports of `buildSystemPrompt` and related types from `client.ts`, as prompt construction is now handled outside.